### PR TITLE
Update setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "cdisutils",
         "psqlgraph~=1.2",
         "dictionaryutils>=1.2.0",
-        "gdcdictionary~=0.2",
+        "gdcdictionary~=1.2",
         "gdcdatamodel~=1.1",
     ],
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
         "cdisutils",
         "psqlgraph~=1.2",
         "dictionaryutils>=1.2.0",
-        "gdcdictionary~=1.1",
+        "gdcdictionary~=0.2",
         "gdcdatamodel~=1.1",
     ],
     entry_points={


### PR DESCRIPTION
bump gdcdictionary because error `The 'gdcdictionary~=1.1' distribution was not found and is required by datamodelutils` is thrown when using `datamodelutils` during sheepdog setup.

The latest version is actually 0.2.1, not 1.1.0...

Edit: new release is 1.2.0

### Dependency updates
- gdcdictionary latest version
