### PR TITLE
PD-13 Fix call to sqlalchemy 'has_table'

### DIFF
--- a/datamodelutils/postgres_admin.py
+++ b/datamodelutils/postgres_admin.py
@@ -163,7 +163,7 @@ def check_version(driver):
     loaded in memory. False if the database doesn't track version
     """
     if "root" in dictionary.schema:
-        if not (driver.engine.dialect.has_table(driver.engine, "node_root")):
+        if not sa.inspect(driver.engine).has_table("node_root"):
             return False
         with driver.session_scope():
             root_node = driver.nodes(models.Root).first()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datamodelutils"
-version = "1.1.1"
+version = "1.1.2"
 description = "Gen3 Data Model Utils"
 authors = ["CTDS UChicago <cdis@uchicago.edu>"]
 license = "Apache-2.0"


### PR DESCRIPTION
```
  File "/Users/paulineribeyre/.virtualenvs/sheepdog-3.9-v2/lib/python3.9/site-packages/datamodelutils/postgres_admin.py", line 166, in check_version
    if not (driver.engine.dialect.has_table(driver.engine, "node_root")):
  File "/Users/paulineribeyre/.virtualenvs/sheepdog-3.9-v2/lib/python3.9/site-packages/sqlalchemy/dialects/postgresql/base.py", line 3636, in has_table
    self._ensure_has_table_connection(connection)
  File "/Users/paulineribeyre/.virtualenvs/sheepdog-3.9-v2/lib/python3.9/site-packages/sqlalchemy/engine/default.py", line 342, in _ensure_has_table_connection
    raise exc.ArgumentError(
sqlalchemy.exc.ArgumentError: The argument passed to Dialect.has_table() should be a <class
'sqlalchemy.engine.base.Connection'>, got <class 'sqlalchemy.engine.base.Engine'>. Additionally,
the Dialect.has_table() method is for internal dialect use only; please use
``inspect(some_engine).has_table(<tablename>>)`` for public API use.
```

Link to JIRA ticket if there is one: https://ctds-planx.atlassian.net/browse/PD-13

### New Features

### Breaking Changes

### Bug Fixes
- Fix call to sqlalchemy 'has_table'

### Improvements

### Dependency updates

### Deployment changes
<!-- This section should only contain important things devops should know when updating service versions. -->
